### PR TITLE
Mobile view updates (#32)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="bg-bg">
     <title>davidjonathanlewis</title>
   </head>
   <body>

--- a/frontend/src/components/Carousel/CarouselArrows.tsx
+++ b/frontend/src/components/Carousel/CarouselArrows.tsx
@@ -10,7 +10,7 @@ export const CarouselArrows: React.FC<{ api: CarouselAPI }> = ({ api }) => {
         aria-label="Previous slide"
         onClick={api.prev}
         className="
-          absolute left-3 top-1/2 -translate-y-1/2
+          absolute left-6 sm:left-3 bottom-3 sm:bottom-auto sm:top-1/2 sm:-translate-y-1/2
           z-10
           rounded-full
           bg-black/50 text-white
@@ -27,7 +27,7 @@ export const CarouselArrows: React.FC<{ api: CarouselAPI }> = ({ api }) => {
         aria-label="Next slide"
         onClick={api.next}
         className="
-          absolute right-3 top-1/2 -translate-y-1/2
+          absolute right-6 sm:right-3 bottom-3 sm:bottom-auto sm:top-1/2 sm:-translate-y-1/2
           z-10
           rounded-full
           bg-black/50 text-white

--- a/frontend/src/components/Carousel/Slide.tsx
+++ b/frontend/src/components/Carousel/Slide.tsx
@@ -5,12 +5,12 @@ const Slide: React.FC<{ slide: SlideResponse }> = ({ slide }) => {
   const navigate = useNavigate();
   
   return (
-    <div className="w-full h-full flex items-center justify-center bg-surface">
-      <div className="w-full h-full px-8 py-12 text-center space-y-6 flex flex-col items-center justify-center">
-        <h3 className="text-5xl font-semibold text-main">
+    <div className="w-full h-full flex items-center justify-center bg-surface overflow-hidden">
+      <div className="w-full h-full px-6 py-10 sm:px-8 sm:py-12 text-center space-y-6 flex flex-col items-center justify-center">
+        <h3 className="text-3xl sm:text-5xl font-semibold text-main break-words">
           {slide.title}
         </h3>
-        <p className="text-xl text-muted leading-relaxed max-w-4xl px-5">
+        <p className="text-base sm:text-xl text-muted leading-relaxed max-w-full sm:max-w-4xl px-4 sm:px-5 break-words">
           {slide.content}
         </p>
         <div

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -9,7 +9,8 @@ function Navbar() {
         {text: 'Contact Me', path: '/contact'}
     ];
     return (
-        <div className="flex gap-3 sm:gap-4 md:gap-5 px-4 sm:px-6 md:px-8 py-2 sm:py-3 md:py-4 navbar">
+        // make navbar sticky on small screens and ensure it renders above content
+        <div className="sticky top-0 z-50 flex gap-3 sm:gap-4 md:gap-5 px-4 sm:px-6 md:px-8 py-2 sm:py-3 md:py-4 navbar">
             {options.map((option, id) => (
                 <li 
                     key={id}

--- a/frontend/src/components/PictureCard.tsx
+++ b/frontend/src/components/PictureCard.tsx
@@ -7,7 +7,7 @@ interface PictureCard {
 function PictureCard ({ img_path, caption }: PictureCard) {
     
     return (
-        <div className="m-8 p-4 space-y-2 rounded-2xl border border-neutral-800 bg-surface transition hover:-translate-y-1 hover:shadow-xl">
+        <div className="m-1 lg:m-8 p-2 lg:p-4 space-y-1 lg:space-y-2 rounded-2xl border border-neutral-800 bg-surface transition hover:-translate-y-1 hover:shadow-xl">
             <img className="aspect-square w-full rounded-2xl"src={img_path}/>
             <p className="text-muted text-sm">{caption}</p>
         </div>

--- a/frontend/src/components/projects/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard.tsx
@@ -28,7 +28,7 @@ function ProjectCard ({ title, description, tech, github, demo, status, path }: 
 
             <div className="mt-4 flex flex-wrap gap-2">
                 {tech.map(t => (
-                <span key={t} className="rounded-full bg-brand px-3 py-1 text-xs">
+                <span key={t} className="rounded-full bg-brand px-3 py-1 text-xs text-main">
                     {t}
                 </span>
                 ))}

--- a/frontend/src/components/projects/ProjectOverview.tsx
+++ b/frontend/src/components/projects/ProjectOverview.tsx
@@ -6,18 +6,22 @@ function ProjectOverview ({ title, tech, github, demo, status, content }: Projec
 
     return (
         <div className="p-5 h-full overflow-y-scroll">
-            <div className="flex gap-5 items-center">
+            {/* title with tags; on mobile stack vertically */}
+            <div className="flex flex-col sm:flex-row gap-5 items-start sm:items-center">
                 <h2 className="text-5xl font-bold text-main">{title}</h2>
-                <div className="flex gap-3 items-center">
-                    <StatusTag status={status}/>
-                    <div className="w-px self-stretch bg-white"/>
-                    {tech && <div className="flex flex-wrap gap-3 items-center">
-                        {tech.map(t => (
-                        <span key={t} className="rounded-full bg-brand px-3 py-1 text-sm text-main">
-                            {t}
-                        </span>
-                        ))}
-                    </div>}
+                <div className="flex flex-col sm:flex-row gap-3 items-start sm:items-center">
+                    <StatusTag status={status} />
+                    {/* divider only when side-by-side */}
+                    <div className="hidden sm:block w-px self-stretch bg-white" />
+                    {tech && (
+                        <div className="flex flex-wrap gap-3 items-center">
+                            {tech.map(t => (
+                                <span key={t} className="rounded-full bg-brand px-3 py-1 text-sm text-main">
+                                    {t}
+                                </span>
+                            ))}
+                        </div>
+                    )}
                 </div>
             </div>
             <hr className="prose max-w-none my-8"/>

--- a/frontend/src/pages/AboutMe.tsx
+++ b/frontend/src/pages/AboutMe.tsx
@@ -10,11 +10,11 @@ import ResumeLink from '../components/ResumeLink.tsx'
 
 function AboutMe() {
     return (
-    <div className="bg-bg w-full h-screen flex flex-col">
+    <div className="bg-bg w-full lg:h-screen flex flex-col">
         <Navbar/>
 
-        <div className="flex flex-col lg:flex-row flex-1 overflow-hidden page-padding">
-            <div className="p-4 sm:p-6 lg:p-8 text-main w-full lg:w-1/2 overflow-y-auto">
+        <div className="flex flex-col lg:flex-row flex-1 lg:overflow-hidden page-padding">
+            <div className="p-4 sm:p-6 lg:p-8 text-main w-full lg:w-1/2 lg:overflow-y-auto">
                 <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl text-left font-thin text-accent animate-fadeInFirst">About Me</h1>
                 <div className="animate-slideInLeft">
                     <h2 className="text-2xl sm:text-3xl font-bold pt-6 sm:pt-10">Who am I?</h2>
@@ -27,7 +27,8 @@ function AboutMe() {
                         <p className="text-lg sm:text-xl text-muted pb-6 lg:pb-0">There's no good generalized answer to that question. However, if my <ResumeLink svg={false}/> doesn't convince you, please look through my projects to get a better understanding of my capabilities.</p>
                 </div>
             </div>
-            <div className="w-full lg:w-1/2 grid grid-cols-1 sm:grid-cols-2 gap-4 p-4 overflow-y-auto animate-slideInRight">
+            <h2 className="lg:hidden text-3xl sm:text-4xl font-bold pt-6 sm:pt-10 px-4 text-main text-center">Some Pictures</h2>
+            <div className="w-full lg:w-1/2 grid grid-cols-1 lg:grid-cols-2 gap-1 lg:gap-4 px-1 py-0.5 lg:p-4 lg:overflow-y-auto animate-slideInRight">
                 <PictureCard caption="My ACM Projects team after winning first place" img_path={ACM}/>
                 <PictureCard caption="My cheerful brother" img_path={Brother}/>
                 <PictureCard caption="UTD Galaxsea at the 2025 RoboBoat competition" img_path={Galaxsea}/>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -132,10 +132,11 @@ function Home() {
                 </div>
               </div>
               
-              <div className="bg-linear-to-br from-bg to-transparent rounded-lg p-5 shadow-lg">
+              <div className="bg-linear-to-br from-bg to-transparent rounded-lg px-2 sm:px-5 py-5 shadow-lg">
                 <Carousel
                   autoplay
-                  className="w-full aspect-video rounded-4xl"
+                  // allow taller carousel on small screens, revert to 16:9 aspect on larger
+                  className="w-full h-[60vh] sm:aspect-video sm:h-auto rounded-4xl"
                   renderArrows={(api) => <CarouselArrows api={api} />}
                   renderIndicators={(api) => <CarouselIndicators api={api} />}
                 >

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -13,13 +13,28 @@ function Projects() {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
-    //display first project if no project has been selected
-    const pathEnding = location.pathname.substring(location.pathname.lastIndexOf('/')+1);
+    // detect whether we're on a mobile screen (tailwind `lg` breakpoint at 1024px)
+    const useIsMobile = () => {
+        const [isMobile, setIsMobile] = useState<boolean>(
+            typeof window !== 'undefined' ? window.innerWidth < 1024 : false
+        );
+        useEffect(() => {
+            const onResize = () => setIsMobile(window.innerWidth < 1024);
+            window.addEventListener('resize', onResize);
+            return () => window.removeEventListener('resize', onResize);
+        }, []);
+        return isMobile;
+    };
+
+    const pathEnding = location.pathname.substring(location.pathname.lastIndexOf('/') + 1);
+    const isMobile = useIsMobile();
+
+    // display first project if no project has been selected (desktop only)
     useEffect(() => {
-        if(projects[0] && pathEnding === 'projects') {
+        if (!isMobile && projects[0] && pathEnding === 'projects') {
             navigate(projects[0].path, { replace: true });
         }
-    })
+    }, [isMobile, projects, pathEnding, navigate]);
 
     // Fetch projects
     useEffect(() => {
@@ -45,36 +60,81 @@ function Projects() {
 
     }, []); // empty dependency → runs once on mount
 
-    // if (loading) return <p>Loading projects...</p>;
+    if (loading) return <p>Loading projects...</p>;
     if (error) return <p>Error: {error}</p>;
     
 
     const selectedProjectIndex = projects.findIndex(project => project.path === pathEnding);
 
     return (
-    <div className="bg-bg w-full h-screen flex flex-col">
-        <Navbar/>
-        <div className="flex flex-col lg:flex-row flex-1 overflow-hidden">
-            <div className="p-4 sm:p-6 lg:p-8 text-main w-full lg:w-1/2 overflow-y-auto">
-                <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl text-left text-main font-thin pb-6 sm:pb-8 text-accent animate-slideInLeftFirst">Projects</h1>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-x-4 sm:gap-y-8">
-                    { !loading && projects.map((project, id) => (    
-                        <div onClick={() => console.log(project.title)} key={id}>
-                            <li 
-                                className="text-main text-xl sm:text-2xl">
-                                <ProjectCard {...project}/>
-                            </li>
+        <div className="bg-bg w-full lg:h-screen flex flex-col">
+            <Navbar />
+
+            {/* mobile vs desktop layouts */}
+            {isMobile ? (
+                // mobile: either show list or overview exclusively
+                pathEnding === 'projects' ? (
+                    <div className="flex-1 overflow-y-auto p-4 sm:p-6">
+                        <h1 className="text-4xl sm:text-5xl font-thin text-accent pb-6 sm:pb-8 animate-slideInLeftFirst">
+                            Projects
+                        </h1>
+                        <div className="flex flex-col gap-4">
+                            {!loading &&
+                                projects.map((project, id) => (
+                                    <div
+                                        key={id}
+                                        onClick={() => navigate(`/projects/${project.path}`)}
+                                    >
+                                        <ProjectCard {...project} />
+                                    </div>
+                                ))}
                         </div>
-                    ))}
+                    </div>
+                ) : (
+                    <div className="flex-1 overflow-y-auto p-4 sm:p-6">
+                        <button
+                            className="mb-4 inline-flex items-center gap-1 text-accent bg-surface px-3 py-1 rounded-full hover:bg-accent/20 transition"
+                            onClick={() => navigate('/projects')}
+                        >
+                            <span className="text-xl">&larr;</span>
+                            <span>Back</span>
+                        </button>
+                        {!loading && projects[selectedProjectIndex] && (
+                            <ProjectOverview {...projects[selectedProjectIndex]} />
+                        )}
+                    </div>
+                )
+            ) : (
+                // desktop: original two-column layout
+                <div className="flex flex-col lg:flex-row flex-1 lg:overflow-hidden">
+                    <div className="p-4 sm:p-6 lg:p-8 text-main w-full lg:w-1/2 lg:overflow-y-auto">
+                        <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl text-left text-main font-thin pb-6 sm:pb-8 text-accent animate-slideInLeftFirst">
+                            Projects
+                        </h1>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-x-4 sm:gap-y-8">
+                            {!loading &&
+                                projects.map((project, id) => (
+                                    <div
+                                        onClick={() => console.log(project.title)}
+                                        key={id}
+                                    >
+                                        <li className="text-main text-xl sm:text-2xl">
+                                            <ProjectCard {...project} />
+                                        </li>
+                                    </div>
+                                ))}
+                        </div>
+                    </div>
+                    <div className="hidden lg:block w-0.5 self-stretch bg-gray-700 animate-fadeIn" />
+                    <div className="w-full lg:w-1/2 pl-0 lg:pl-2 lg:overflow-y-auto animate-slideInRight">
+                        {!loading && (
+                            <ProjectOverview {...projects[selectedProjectIndex]} />
+                        )}
+                    </div>
                 </div>
-            </div>
-            <div className="hidden lg:block w-0.5 self-stretch bg-gray-700 animate-fadeIn"/>
-            <div className="w-full lg:w-1/2 pl-0 lg:pl-2 overflow-y-auto animate-slideInRight">
-                {!loading && (<ProjectOverview {...projects[selectedProjectIndex]}/>)}
-            </div>
+            )}
         </div>
-    </div>
-    )
+    );
 }
 
 export default Projects

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -7,6 +7,15 @@
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
 }
 
+html,
+body {
+  background-color: var(--bg);
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+}
+
 li{
   list-style-type: none; /* Removes the bullet points */
 }

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -41,6 +41,10 @@
 .navbar {
   background: var(--nav);
   border-bottom: 1px solid var(--border);
+  /* ensure navbar sticks to the top on smaller viewports */
+  position: sticky;
+  top: 0;
+  z-index: 50;
 }
 
 .nav-link {


### PR DESCRIPTION
* fix: update slides fixed on mobile

fixes #28

* fix: mobile view of about me page

converts two column format into one long scrollable page of text then pictures

fixes #29

* fix: sticky navbar

fixes #31

* fix(navbar): sticky navbar on contact page

fixes #31

* fix(projects): project page mobile view

only show either the project cards or the project overview on mobile, not both

fixes #30

* fix(contact): remove white footer caused by updating sticky navbar

* fix: weird project scrolling content but not the entire page

* fix: background beyond the content is now background color

* fix: safari address bar color

* fix: mobile update slide arrows

move the update slide arrows to the bottom left and right corner to prevent text overlap on mobile view

* fix: remove duplicate test projects